### PR TITLE
Add support for diffusers 0.29.0

### DIFF
--- a/lib_layerdiffusion/models.py
+++ b/lib_layerdiffusion/models.py
@@ -7,19 +7,22 @@ from tqdm import tqdm
 from typing import Optional, Tuple
 from diffusers.configuration_utils import ConfigMixin, register_to_config
 from diffusers.models.modeling_utils import ModelMixin
-from diffusers.models.unet_2d_blocks import UNetMidBlock2D, get_down_block, get_up_block
+import importlib.metadata
+from packaging.version import parse
 
+diffusers_version = importlib.metadata.version('diffusers')
 
-def check_diffusers_version():
-    import diffusers
-    from packaging.version import parse
-
-    assert parse(diffusers.__version__) >= parse(
-        "0.25.0"
-    ), "diffusers>=0.25.0 requirement not satisfied. Please install correct diffusers version."
-
+def check_diffusers_version(min_version="0.25.0"):
+    assert parse(diffusers_version) >= parse(
+        min_version
+    ), f"diffusers>={min_version} requirement not satisfied. Please install correct diffusers version."
 
 check_diffusers_version()
+
+if parse(diffusers_version) >= parse("0.29.0"):
+    from diffusers.models.unets.unet_2d_blocks import UNetMidBlock2D, get_down_block, get_up_block
+else:
+    from diffusers.models.unet_2d_blocks import UNetMidBlock2D, get_down_block, get_up_block
 
 
 def zero_module(module):


### PR DESCRIPTION
There is a breaking change in diffusers 0.29.0 because the UNet blocks have been moved.

Fixes #86 

> Diffusers package has moved unet_2d_blocks.py into the "diffusers/models/unets/" path instead of the former "diffusers/models/" path. Line 10 in "lib_layerdiffusion/models.py" should be changed from from diffusers.models.unet_2d_blocks import UNetMidBlock2D, get_down_block, get_up_block to from diffusers.models.unets.unet_2d_blocks import UNetMidBlock2D, get_down_block, get_up_block.

This PR does a version check before loading the UNet blocks to maintain backwards compatibility.
